### PR TITLE
Fix security alert WS-2018-0590 - update diff

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -798,9 +798,9 @@
       "dev": true
     },
     "diff": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-1.4.0.tgz",
-      "integrity": "sha1-fyjS657nsVqX79ic5j3P2qPMur8=",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.1.tgz",
+      "integrity": "sha512-s2+XdvhPCOF01LRQBC8hf4vhbVmI2CGS5aZnxLJlT5FtdhPCDFq80q++zK2KlrVorVDdL5BOGZ/VfLrVtYNF+Q==",
       "dev": true
     },
     "domain-browser": {


### PR DESCRIPTION
Fixing git security alert for this repo [WS-2018-0590](https://github.com/kpdecker/jsdiff/commit/2aec4298639bf30fb88a00b356bf404d3551b8c0) (`diff`).

Updating diff version to most-recent one as in: https://github.com/awslabs/aws-cdk/blob/master/packages/%40aws-cdk/cloudformation-diff/package-lock.json

May be a good thing to update all other dependencies, too. This PR only updates diff to fix the security alert.